### PR TITLE
allow nokogiri 1.7 and update to rspec 3.x

### DIFF
--- a/ruby_powerpoint.gemspec
+++ b/ruby_powerpoint.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency 'rspec', '~> 2.13.0'
+  spec.add_development_dependency 'rspec', '~> 3'
 
-  spec.add_dependency 'nokogiri', '~> 1.6.0'
-  spec.add_dependency 'rubyzip', '~> 1.0'  
+  spec.add_dependency 'nokogiri', '~> 1.6'
+  spec.add_dependency 'rubyzip', '~> 1.0'
 end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -2,7 +2,7 @@ require 'ruby_powerpoint'
 
 describe 'RubyPowerpoint trying to parsing an invalid file.' do
   it 'not open an XLS file successfully.' do
-    lambda { RubyPowerpoint::Presentation.new 'specs/fixtures/invalid.xls' }.should raise_error 'Not a valid file format.'
+    expect { RubyPowerpoint::Presentation.new 'specs/fixtures/invalid.xls' }.to raise_error 'Not a valid file format.'
   end
 end
 
@@ -16,23 +16,23 @@ describe 'RubyPowerpoint parsing a sample PPTX file' do
   end
 
   it 'parse a PPTX file successfully.' do
-    @deck.should_not be_nil
-    @deck.slides.should_not eql []
-    @deck.slides.first.content.should eql ["Some test ", "Powerpoint"]
-    @deck.slides.first.content.should eql  ["Some test ", "Powerpoint"]
+    expect(@deck).to_not be_nil
+    expect(@deck.slides).to_not eql []
+    expect(@deck.slides.first.content).to eql ["Some test ", "Powerpoint"]
+    expect(@deck.slides.first.content).to eql  ["Some test ", "Powerpoint"]
     image_byte_stream_1 = @deck.slides.first.images.first.read
     File.open('temp_1.jpg', 'w'){|f| f.puts image_byte_stream_1}
 
-    @deck.slides.first.images.first.should_not eql nil #"ppt/media/image1.jpeg"
-    @deck.slides.last.title.should eql "Some title here"
-    @deck.slides.last.content.should eql ["Some title here", "Some txt here", "Some ", "more text here."]
+    expect(@deck.slides.first.images.first).to_not eql nil #"ppt/media/image1.jpeg"
+    expect(@deck.slides.last.title).to eql "Some title here"
+    expect(@deck.slides.last.content).to eql ["Some title here", "Some txt here", "Some ", "more text here."]
     image_byte_stream_2 = @deck.slides.last.images.first.read
     File.open('temp_2.jpg', 'w'){|f| f.puts image_byte_stream_2}
   end
 
   it "it parses Slide Notes of a PPTX  slides" do
     notes_content = @deck.slides[0].notes_content
-    notes_content.should eql ["Testing", " Multiline Notes.", "To be extracted here.", "Multiline notes extracted.", "1"]
+    expect(notes_content).to eql ["Testing", " Multiline Notes.", "To be extracted here.", "Multiline notes extracted.", "1"]
   end
 
 end
@@ -47,36 +47,36 @@ describe 'open rime.pptx file' do
   end
 
   it 'opened rime.pptx successfully' do
-    @deck.should_not be_nil
-    @deck.slides.should_not eql []
+    expect(@deck).to_not be_nil
+    expect(@deck.slides).to_not eql []
   end
 
   it 'should have the right number of slides' do
-    @deck.slides.length.should eql 12
+    expect(@deck.slides.length).to eql 12
   end
 
   it 'the old content method should work the same way' do
-    @deck.slides[0].content.should eql ["The Rime of the Ancient Mariner", "(text of 1834)", "http://rpo.library.utoronto.ca/poems/rime-ancient-mariner-text-1834"]
+    expect(@deck.slides[0].content).to eql ["The Rime of the Ancient Mariner", "(text of 1834)", "http://rpo.library.utoronto.ca/poems/rime-ancient-mariner-text-1834"]
   end
 
   context 'the titles should be right' do
     it 'should be able to get a main slide (usually centered)' do
-      @deck.slides[0].title.should eql "The Rime of the Ancient Mariner"
+      expect(@deck.slides[0].title).to eql "The Rime of the Ancient Mariner"
     end
     it 'should be able to get regular slide titles' do
-      @deck.slides[1].title.should eql "Argument"
-      @deck.slides[2].title.should eql "PART I"
-      @deck.slides[3].title.should eql "PART II"
-      @deck.slides[4].title.should eql "Part III"
-      @deck.slides[8].title.should eql "There's more"
+      expect(@deck.slides[1].title).to eql "Argument"
+      expect(@deck.slides[2].title).to eql "PART I"
+      expect(@deck.slides[3].title).to eql "PART II"
+      expect(@deck.slides[4].title).to eql "Part III"
+      expect(@deck.slides[8].title).to eql "There's more"
     end
     it 'should return nil if the slide has no title' do
-      @deck.slides[5].title.should be_nil
-      @deck.slides[6].title.should be_nil
+      expect(@deck.slides[5].title).to be_nil
+      expect(@deck.slides[6].title).to be_nil
     end
 
     it 'should only get one title even if there are two things that visually look like titles' do
-      @deck.slides[7].title.should eql "What if we have two"
+      expect(@deck.slides[7].title).to eql "What if we have two"
     end
 
     context 'when slide contains paragraph' do
@@ -85,11 +85,11 @@ describe 'open rime.pptx file' do
       end
 
       it 'should return the list of paragraphs' do
-        @slide.paragraphs.count.should eql 2
+        expect(@slide.paragraphs.count).to eql 2
       end
 
       it 'should return the content of the paragraph' do
-        @slide.paragraphs[0].content.should eq ['Argument']
+        expect(@slide.paragraphs[0].content).to eq ['Argument']
       end
     end
   end


### PR DESCRIPTION
Primary change: Loosen the gemspec dependency on nokogiri, to allow use of this gem with Nokogiri 1.7+

Related:
- Update rspec to 3.x (in particular, so that the tests can run with rake 12.x, which was previously failing with `NoMethodError: undefined method 'last_comment' for #<Rake::Application:0x007f87351f77c8>`)
- Minimally update the rspec expectations to use the modern `expect().to ...` syntax, to fix warnings under rspec 3.x
