### PR TITLE
Update `rubyzip` version

### DIFF
--- a/ruby_powerpoint.gemspec
+++ b/ruby_powerpoint.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3'
 
   spec.add_dependency 'nokogiri', '~> 1.6'
-  spec.add_dependency 'rubyzip', '~> 1.0'
+  spec.add_dependency 'rubyzip', '~> 2.0'
 end


### PR DESCRIPTION
Hello @pythonicrubyist 👋
First of all, thank you for this nice gem!

I would like to use this gem, but it conflicts `rubyzip` dependency with other gem like [docx](https://github.com/ruby-docx/docx/blob/471eb150e69e2ca1689a349ab72bfc5b648714e1/docx.gemspec#L17).
So, could you update `rubyzip` dependency? 🙏 

I checked that all tests pass.

```shell
$ bundle exec rspec
............

Finished in 0.09584 seconds (files took 0.16522 seconds to load)
12 examples, 0 failures
```
